### PR TITLE
Add support for modifying /etc/hosts

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyflop/pyflop.py
+++ b/pyflop/pyflop.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
+import argparse
 import glob
 import subprocess
-from typing import Iterable
+import sys
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from ipaddress import IPv4Address
-from contextlib import contextmanager
-import argparse
-
+from typing import Iterable
 
 FIRST_IP = IPv4Address("10.10.0.1")
 SCHEME_MAP = {80: "http://", 443: "https://", 5900: "vnc://", 3389: "rdp://"}
@@ -62,6 +62,24 @@ class Interface:
         finally:
             subprocess.run(f"sudo ip link del {self.name}", shell=True)
 
+    @contextmanager
+    def create_hosts_entry(self, remote_hosts: Iterable[str]):
+        # Create a new entry in /etc/hosts for the remote host on this interface ip
+        # Need to capture the output as hostsed does always print the full /etc/hosts contents
+        try:
+            subprocess.run(
+                f"sudo {sys.executable} -m hosts.editor add {self.ipv4} {' '.join(remote_hosts)}",
+                shell=True, capture_output=True
+            )
+            yield self
+        finally:
+            # Explicitly delete the entries made above to avoid removing manual changes
+            for remote_host in remote_hosts:
+                subprocess.run(
+                    f"sudo {sys.executable} -m hosts.editor delete {self.ipv4} {remote_host}",
+                    shell=True, capture_output=True
+                )
+
 
 def create_tunnel(interface: Interface, tunnels: Iterable[Tunnel], remote: str):
     # Create a ssh new tunnel using the interface, local_port, remote_host, and remote_port
@@ -77,6 +95,7 @@ def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="SSH port forwarding using local dummy interfaces"
     )
+    parser.add_argument("--no-hosts", action="store_true", help="Do not modify /etc/hosts")
     tunnels_arg = parser.add_argument(
         "-L",
         dest="tunnels",
@@ -88,6 +107,7 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(dest="remote", help="Remote host")
 
     args = parser.parse_args()
+    args.modify_hosts = not args.no_hosts
 
     tunnels = []
     for tunnel_str in args.tunnels:
@@ -119,13 +139,16 @@ def main():
     args = parse_arguments()
 
     with Interface().create_interface() as interface:
+        remote_hosts = set()
         for tunnel in args.tunnels:
+            remote_hosts.add(tunnel.remote_host)
             scheme = SCHEME_MAP.get(tunnel.local_port, "")
             print(
                 f"Tunnel created: {scheme}{interface.ipv4}:{tunnel.local_port}"
                 f" -> {tunnel.remote_host}:{tunnel.remote_port}"
             )
-        create_tunnel(interface, args.tunnels, args.remote)
+        with interface.create_hosts_entry(remote_hosts) if args.modify_hosts else nullcontext():
+            create_tunnel(interface, args.tunnels, args.remote)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup, find_packages
 
 setup(
     name="pyflop",
-    version="1.0.0",
+    version="1.1.0",
     packages=find_packages(),
     entry_points={
         'console_scripts': [
             'pyflop=pyflop.pyflop:main',
         ],
     },
-    install_requires=[],
+    install_requires=["hostsed"],
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     python_requires='>=3.9',

--- a/tests/test_pyflop.py
+++ b/tests/test_pyflop.py
@@ -1,9 +1,11 @@
-import unittest
-from unittest.mock import patch, call
-from ipaddress import IPv4Address
 import subprocess
-from pyflop.pyflop import Tunnel, Interface, create_tunnel, parse_arguments
+import sys
+import unittest
 from argparse import ArgumentError
+from ipaddress import IPv4Address
+from unittest.mock import call, patch
+
+from pyflop.pyflop import Interface, Tunnel, create_tunnel, parse_arguments
 
 
 def mock_run_side_effect(cmd, *args, **kwargs):
@@ -42,6 +44,32 @@ class TestInterface(unittest.TestCase):
             ),
             call(f"sudo ip link set {interface.name} up", shell=True),
             call(f"sudo ip link del {interface.name}", shell=True),
+        ]
+        self.assertEqual(mock_run.call_args_list, expected_call_args)
+
+    @patch("subprocess.run", side_effect=mock_run_side_effect)
+    def test_create_hosts_entry(self, mock_run, mock_glob):
+        interface = Interface()
+        with interface.create_hosts_entry(("n0.pyflop.com", "n1.pyflop.com")) as created_interface:
+            self.assertEqual(created_interface, interface)
+
+        mock_run.call_count = 3
+        expected_call_args = [
+            call(
+                f"sudo {sys.executable} -m hosts.editor add {interface.ipv4} n0.pyflop.com n1.pyflop.com",
+                shell=True,
+                capture_output=True,
+            ),
+            call(
+                f"sudo {sys.executable} -m hosts.editor delete {interface.ipv4} n0.pyflop.com",
+                shell=True,
+                capture_output=True,
+            ),
+            call(
+                f"sudo {sys.executable} -m hosts.editor delete {interface.ipv4} n1.pyflop.com",
+                shell=True,
+                capture_output=True,
+            ),
         ]
         self.assertEqual(mock_run.call_args_list, expected_call_args)
 


### PR DESCRIPTION
pyflop will add an entry to /etc/hosts by default now which maps the pyflop interface IP to the remote hosts provided.

This can be disabled via the --no-hosts parameter.